### PR TITLE
docs: Fixes some echo cmds in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ AWS (t3.large)
 
 ### Prerequisites
 
-Get the following file from the [Haven1 Team](mailto:contact@haven1.org)
+Get the following files from the [Haven1 Team](mailto:contact@haven1.org)
 
 - genesis.base64 (base 64 encoded)
 - link for cosigner image
@@ -305,7 +305,7 @@ Connect to the validator instance with EC2 Instance Connect and run the followin
 
     ```bash
     printf "\n\n\n\n Copy the following Data \n\n\n"
-    echo -n "AWS KMS Cosigner Public Key: $(aws kms get-public-key --key-id=alias/Haven1-Validator --query 'PublicKey' --output text)"
+    echo "AWS KMS Cosigner Public Key: $(aws kms get-public-key --key-id=alias/Haven1-Validator --query 'PublicKey' --output text)"
     for file in keystore/address keystore/nodekey.pub .env; do printf "%s: %s\n" "$file" "$(cat "$file")"; done
     printf "\n\n\n\n"
     ```
@@ -462,7 +462,7 @@ Connect to the archive instance with EC2 Instance Connect and run the following 
 
     ```bash
     printf "\n\n\n\n Copy the following Data \n\n\n"
-    echo -n "AWS KMS Signer Public Key: $(aws kms get-public-key --key-id=alias/Haven1-Signing --query 'PublicKey' --output text)"
+    echo "AWS KMS Signer Public Key: $(aws kms get-public-key --key-id=alias/Haven1-Signing --query 'PublicKey' --output text)"
     for file in keystore/nodekey.pub .env; do printf "%s: %s\n" "$file" "$(cat "$file")"; done
     printf "\n\n\n\n"
     ```


### PR DESCRIPTION
**Changes**:
- Removes the `do not output trailing newline` `-n` flag from some `echo` commands, to ensure extracted keys are printed on seperate lines.
- Minor spelling.